### PR TITLE
fix: apply modem fix 

### DIFF
--- a/drivers/modem/quectel-bg95.c
+++ b/drivers/modem/quectel-bg95.c
@@ -780,6 +780,8 @@ MODEM_CMD_DEFINE(on_cmd_sockreadfrom)
 
     if (i >= (len + 7)) {
         LOG_ERR("Wrong format in QSSLRECV");
+        // FIX for infinite loop if corrupted QSSLRECV
+        data->rx_buf = net_buf_skip(data->rx_buf, len);
         return -EINVAL; /* FIXME */
     }
 


### PR DESCRIPTION
This PR applies the modem fix for QSSLRECV infinite loop hang fix . Updated the zb_actipod_app submodule pointer to the correct commit from `zb_actipod_app/main`.

This ensures the branch is safe to merge into `main` and has a clean submodule state.
