### PR TITLE
Support for I2C Recovery for BMS and Temp

### DIFF
--- a/boards/arm/zb_tv_h723zi/zb_tv_h723zi.dts
+++ b/boards/arm/zb_tv_h723zi/zb_tv_h723zi.dts
@@ -290,6 +290,37 @@ zephyr_udc0: &usbotg_hs {
 	status = "okay";
 };
 
+/ {
+   /* Standalone node for I2C2 recovery (PF1/PF0) */
+    i2c2_recovery: i2c2_recovery {
+        compatible = "gpio-keys";
+        scl_rec_i2c2: scl_rec_i2c2 {
+            gpios = <&gpiof 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                       label = "RECOVERY_I2C2_SCL";
+        };
+        sda_rec_i2c2: sda_rec_i2c2 {
+            gpios = <&gpiof 0 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                       label = "RECOVERY_I2C2_SDA";
+        };
+    };
+};
+
+/ {
+    /* Standalone node for I2C1 recovery (PB6/PB7) */
+    i2c1_recovery: i2c1_recovery {
+        compatible = "gpio-keys";
+        scl_rec_i2c1: scl_rec_i2c1 {
+            gpios = <&gpiob 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+            label = "RECOVERY_I2C1_SCL";
+        };
+        sda_rec_i2c1: sda_rec_i2c1 {
+            gpios = <&gpiob 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+            label = "RECOVERY_I2C1_SDA";
+        };
+    };
+};
+
+
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
     pinctrl-names = "default";

--- a/boards/arm/zb_tv_h743zi/zb_tv_h743zi.dts
+++ b/boards/arm/zb_tv_h743zi/zb_tv_h743zi.dts
@@ -285,6 +285,36 @@ zephyr_udc0: &usbotg_hs {
 	status = "okay";
 };
 
+/ {
+     /* Standalone node for I2C2 recovery (PF1/PF0) */
+    i2c2_recovery: i2c2_recovery {
+        compatible = "gpio-keys";
+        scl_rec_i2c2: scl_rec_i2c2 {
+            gpios = <&gpiof 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                       label = "RECOVERY_I2C2_SCL";
+        };
+        sda_rec_i2c2: sda_rec_i2c2 {
+            gpios = <&gpiof 0 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                       label = "RECOVERY_I2C2_SDA";
+        };
+    };
+};
+
+/ {
+    /* Standalone node for I2C1 recovery (PB6/PB7) */
+    i2c1_recovery: i2c1_recovery {
+        compatible = "gpio-keys";
+        scl_rec_i2c1: scl_rec_i2c1 {
+            gpios = <&gpiob 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+            label = "RECOVERY_I2C1_SCL";
+        };
+        sda_rec_i2c1: sda_rec_i2c1 {
+            gpios = <&gpiob 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+            label = "RECOVERY_I2C1_SDA";
+        };
+    };
+};
+
 &i2c1 {
 	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
     pinctrl-names = "default";

--- a/drivers/i2c/CMakeLists.txt
+++ b/drivers/i2c/CMakeLists.txt
@@ -3,6 +3,7 @@
 zephyr_library()
 
 zephyr_library_sources(i2c_common.c)
+zephyr_library_sources(i2c_recovery_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_SHELL		i2c_shell.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_BITBANG		i2c_bitbang.c)
 zephyr_library_sources_ifdef(CONFIG_I2C_TELINK_B91		i2c_b91.c)

--- a/drivers/i2c/i2c_recovery_stm32.c
+++ b/drivers/i2c/i2c_recovery_stm32.c
@@ -1,0 +1,77 @@
+
+#include <soc.h>
+#include <stm32_ll_i2c.h>
+#include <stm32_ll_bus.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_gpio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c/i2c_recovery_stm32.h>
+
+
+void i2c_recovery_stm32(I2C_TypeDef *i2c, 
+                                 GPIO_TypeDef *port,
+                                 uint32_t scl_pin, 
+                                 uint32_t sda_pin,
+                                 const struct gpio_dt_spec *scl_dt,
+                                 const struct gpio_dt_spec *sda_dt)
+{
+    // --- STEP 0: CAPTURE STATE ---
+    uint32_t timing_backup = i2c->TIMINGR;
+    uint32_t cr1_backup = i2c->CR1;
+
+    if (timing_backup == 0) return;
+
+    // --- STEP 1: PERIPHERAL SHUTDOWN & RCC RESET ---
+    LL_I2C_Disable(i2c);
+    k_busy_wait(100);
+
+    /* SMART RCC RESET: Identify which I2C we are resetting */
+    if (i2c == I2C1) {
+        LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_I2C1);
+        k_busy_wait(500);
+        LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_I2C1);
+    } 
+    else if (i2c == I2C2) {
+        LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_I2C2);
+        k_busy_wait(500);
+        LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_I2C2);
+    }
+    k_busy_wait(500);
+
+    // --- STEP 2: GPIO TAKEOVER ---
+    LL_GPIO_SetPinMode(port, scl_pin, LL_GPIO_MODE_OUTPUT);
+    LL_GPIO_SetPinMode(port, sda_pin, LL_GPIO_MODE_OUTPUT);
+    LL_GPIO_SetPinOutputType(port, scl_pin, LL_GPIO_OUTPUT_OPENDRAIN);
+    LL_GPIO_SetPinOutputType(port, sda_pin, LL_GPIO_OUTPUT_OPENDRAIN);
+    LL_GPIO_SetPinPull(port, scl_pin, LL_GPIO_PULL_UP);
+    LL_GPIO_SetPinPull(port, sda_pin, LL_GPIO_PULL_UP);
+    k_busy_wait(100);
+
+    // --- STEP 3 & 4: PULSE SWEEP ---
+    for (int i = 0; i < 80; i++) {
+        gpio_pin_set_dt(scl_dt, 0);
+        k_busy_wait(20);
+        gpio_pin_set_dt(scl_dt, 1);
+        k_busy_wait(20);
+    }
+
+    // --- STEP 5: MANUAL STOP ---
+    gpio_pin_set_dt(scl_dt, 0); k_busy_wait(10);
+    gpio_pin_set_dt(sda_dt, 0); k_busy_wait(10);
+    gpio_pin_set_dt(scl_dt, 1); k_busy_wait(10);
+    gpio_pin_set_dt(sda_dt, 1); k_busy_wait(10);
+
+    // --- STEP 6: RESTORE MUX & ENGINE ---
+    LL_GPIO_SetAFPin_0_7(port, sda_pin, LL_GPIO_AF_4);
+    LL_GPIO_SetAFPin_0_7(port, scl_pin, LL_GPIO_AF_4);
+    LL_GPIO_SetPinMode(port, sda_pin, LL_GPIO_MODE_ALTERNATE);
+    LL_GPIO_SetPinMode(port, scl_pin, LL_GPIO_MODE_ALTERNATE);
+
+    i2c->TIMINGR = timing_backup; 
+    i2c->CR1 = (cr1_backup & ~I2C_CR1_PE); 
+    k_busy_wait(100);
+    
+    LL_I2C_Enable(i2c);
+    i2c->ICR = 0xFFFFFFFF;
+}

--- a/drivers/sensor/bq40zxx/bq40zxx.c
+++ b/drivers/sensor/bq40zxx/bq40zxx.c
@@ -7,6 +7,10 @@
 #define DT_DRV_COMPAT ti_bq40zxx
 
 #include <drivers/i2c.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr.h>
+#include <device.h>
+#include <zephyr/drivers/i2c/i2c_recovery_stm32.h>
 #include <init.h>
 #include <drivers/sensor.h>
 #include <sys/__assert.h>
@@ -34,6 +38,13 @@
 
 #define FP    4
 
+
+/* Using the labels defined in your DTS */ //** working code
+static const struct gpio_dt_spec rec_scl = GPIO_DT_SPEC_GET(DT_NODELABEL(scl_rec_i2c2), gpios);
+static const struct gpio_dt_spec rec_sda = GPIO_DT_SPEC_GET(DT_NODELABEL(sda_rec_i2c2), gpios);
+
+
+
 /*******************************************************************
  * ********************** SMBUS block ******************************
  * *****************************************************************/
@@ -43,9 +54,17 @@ static int smbus_block_read(struct bq40zxx_data *bq40zxx, uint8_t reg_addr,
     //LOG_INF("SBR: %d, 0x%x", rd_sz, reg_addr);
     int status = i2c_burst_read(bq40zxx->i2c, DT_INST_REG_ADDR(0),
             reg_addr, rd_buf, rd_sz);
-	if (status < 0) {
-		LOG_DBG("Unable to read register");
-		return -EIO;
+	if (status == -EBUSY || status == -EIO || status == -ETIMEDOUT) {
+        LOG_DBG("Recovery Initiated");
+        i2c_recovery_stm32(I2C2, GPIOF, LL_GPIO_PIN_1, LL_GPIO_PIN_0, &rec_scl, &rec_sda);
+        // Re-attempt once
+        status = i2c_burst_read(bq40zxx->i2c, DT_INST_REG_ADDR(0),
+            reg_addr, rd_buf, rd_sz);
+        if (status < 0) {
+			LOG_DBG("Unable to read register");
+			return -EIO;
+		
+		}
 	}
     return status;
 }

--- a/drivers/sensor/tmp116/tmp116.c
+++ b/drivers/sensor/tmp116/tmp116.c
@@ -15,6 +15,8 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/kernel.h>
+#include <zephyr/drivers/i2c/i2c_recovery_stm32.h>
+
 
 #include "tmp116.h"
 
@@ -24,6 +26,11 @@
 
 LOG_MODULE_REGISTER(TMP116, CONFIG_SENSOR_LOG_LEVEL);
 
+static const struct gpio_dt_spec rec_scl = GPIO_DT_SPEC_GET(DT_NODELABEL(scl_rec_i2c1), gpios);
+static const struct gpio_dt_spec rec_sda = GPIO_DT_SPEC_GET(DT_NODELABEL(sda_rec_i2c1), gpios);
+
+
+
 static int tmp116_reg_read(const struct device *dev, uint8_t reg,
 			   uint16_t *val)
 {
@@ -31,7 +38,11 @@ static int tmp116_reg_read(const struct device *dev, uint8_t reg,
 
 	if (i2c_burst_read_dt(&cfg->bus, reg, (uint8_t *)val, 2)
 	    < 0) {
-		return -EIO;
+		i2c_recovery_stm32(I2C1, GPIOB, LL_GPIO_PIN_6, LL_GPIO_PIN_7, &rec_scl, &rec_sda);
+		if (i2c_burst_read_dt(&cfg->bus, reg, (uint8_t *)val, 2)
+			< 0) {
+				return -EIO;
+		}
 	}
 
 	*val = sys_be16_to_cpu(*val);

--- a/include/zephyr/drivers/i2c/i2c_recovery_stm32.h
+++ b/include/zephyr/drivers/i2c/i2c_recovery_stm32.h
@@ -1,0 +1,17 @@
+#ifndef I2C_RECOVERY_STM32_H
+#define I2C_RECOVERY_STM32_H
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <stm32_ll_i2c.h>
+#include <stm32_ll_gpio.h>
+#include <stm32_ll_bus.h>
+
+
+void i2c_recovery_stm32(I2C_TypeDef *i2c, 
+                                 GPIO_TypeDef *port,
+                                 uint32_t scl_pin, 
+                                 uint32_t sda_pin,
+                                 const struct gpio_dt_spec *scl_dt,
+                                 const struct gpio_dt_spec *sda_dt);
+#endif


### PR DESCRIPTION

Adds support for I2C bus recovery    and updates the device tree configuration accordingly.

## Changes
- Added I2C bus recovery support for BMS and Temperature Sense
- Updated DTS files to include required configuration for I2C recovery


